### PR TITLE
Make okisaga.html runnable as a standalone React page

### DIFF
--- a/okisaga.html
+++ b/okisaga.html
@@ -1,4 +1,20 @@
-import React, { useState, useCallback, useEffect, useRef } from ‘react’;
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>隠岐海伝説</title>
+    <style>
+      body { margin: 0; background: #000; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel">
+const { useState, useCallback, useEffect, useRef } = React;
 
 // 効果音生成
 const useSound = () => {
@@ -19,7 +35,6 @@ const gain = ctx.createGain();
 osc.connect(gain);
 gain.connect(ctx.destination);
 
-```
   switch (type) {
     case 'attack':
       osc.frequency.setValueAtTime(200, ctx.currentTime);
@@ -124,7 +139,6 @@ gain.connect(ctx.destination);
       break;
   }
 } catch (e) {}
-```
 
 };
 return play;
@@ -132,107 +146,107 @@ return play;
 
 // 職業定義
 const JOBS = {
-fisherman: { name: ‘漁師’, icon: ‘🎣’, color: ‘#4169E1’, baseAtk: 12, baseDef: 8, baseHp: 110, special: ‘shell’, rarity: ‘N’ },
-salaryman: { name: ‘サラリーマン’, icon: ‘👔’, color: ‘#708090’, baseAtk: 10, baseDef: 10, baseHp: 100, special: ‘exp’, rarity: ‘N’ },
-sumo: { name: ‘力士’, icon: ‘🤼’, color: ‘#8B4513’, baseAtk: 15, baseDef: 5, baseHp: 180, special: ‘counter’, rarity: ‘R’ },
-doctor: { name: ‘医者’, icon: ‘👨‍⚕️’, color: ‘#00CED1’, baseAtk: 8, baseDef: 12, baseHp: 100, special: ‘heal’, rarity: ‘R’ },
-diver: { name: ‘海女’, icon: ‘🤿’, color: ‘#20B2AA’, baseAtk: 14, baseDef: 6, baseHp: 90, special: ‘crit’, rarity: ‘R’ },
-chef: { name: ‘料理人’, icon: ‘👨‍🍳’, color: ‘#FF6347’, baseAtk: 10, baseDef: 8, baseHp: 95, special: ‘item’, rarity: ‘SR’ },
-shrine: { name: ‘神主’, icon: ‘⛩️’, color: ‘#9932CC’, baseAtk: 11, baseDef: 11, baseHp: 105, special: ‘divine’, rarity: ‘SR’ },
-captain: { name: ‘船長’, icon: ‘🚢’, color: ‘#FFD700’, baseAtk: 13, baseDef: 13, baseHp: 120, special: ‘double’, rarity: ‘SSR’ },
-emperor: { name: ‘後鳥羽上皇’, icon: ‘👑’, color: ‘#FF4500’, baseAtk: 18, baseDef: 15, baseHp: 150, special: ‘pierce’, rarity: ‘SSR’ },
-dragon: { name: ‘龍神’, icon: ‘🐉’, color: ‘#00FF7F’, baseAtk: 25, baseDef: 20, baseHp: 200, special: ‘all’, rarity: ‘UR’ },
+fisherman: { name: '漁師', icon: '🎣', color: '#4169E1', baseAtk: 12, baseDef: 8, baseHp: 110, special: 'shell', rarity: 'N' },
+salaryman: { name: 'サラリーマン', icon: '👔', color: '#708090', baseAtk: 10, baseDef: 10, baseHp: 100, special: 'exp', rarity: 'N' },
+sumo: { name: '力士', icon: '🤼', color: '#8B4513', baseAtk: 15, baseDef: 5, baseHp: 180, special: 'counter', rarity: 'R' },
+doctor: { name: '医者', icon: '👨‍⚕️', color: '#00CED1', baseAtk: 8, baseDef: 12, baseHp: 100, special: 'heal', rarity: 'R' },
+diver: { name: '海女', icon: '🤿', color: '#20B2AA', baseAtk: 14, baseDef: 6, baseHp: 90, special: 'crit', rarity: 'R' },
+chef: { name: '料理人', icon: '👨‍🍳', color: '#FF6347', baseAtk: 10, baseDef: 8, baseHp: 95, special: 'item', rarity: 'SR' },
+shrine: { name: '神主', icon: '⛩️', color: '#9932CC', baseAtk: 11, baseDef: 11, baseHp: 105, special: 'divine', rarity: 'SR' },
+captain: { name: '船長', icon: '🚢', color: '#FFD700', baseAtk: 13, baseDef: 13, baseHp: 120, special: 'double', rarity: 'SSR' },
+emperor: { name: '後鳥羽上皇', icon: '👑', color: '#FF4500', baseAtk: 18, baseDef: 15, baseHp: 150, special: 'pierce', rarity: 'SSR' },
+dragon: { name: '龍神', icon: '🐉', color: '#00FF7F', baseAtk: 25, baseDef: 20, baseHp: 200, special: 'all', rarity: 'UR' },
 };
 const JOB_IDS = Object.keys(JOBS);
 
 const SHELLS = {
-1: { name: ‘シジミ’, color: ‘#8B7355’, icon: ‘🐚’, itemCost: 10, jobCost: 15 },
-2: { name: ‘アサリ’, color: ‘#CD853F’, icon: ‘🦪’, itemCost: 8, jobCost: 12 },
-3: { name: ‘ハマグリ’, color: ‘#DAA520’, icon: ‘🐚’, itemCost: 5, jobCost: 8 },
-4: { name: ‘サザエ’, color: ‘#228B22’, icon: ‘🐚’, itemCost: 3, jobCost: 5 },
-5: { name: ‘アワビ’, color: ‘#4169E1’, icon: ‘🦪’, itemCost: 1, jobCost: 2 },
+1: { name: 'シジミ', color: '#8B7355', icon: '🐚', itemCost: 10, jobCost: 15 },
+2: { name: 'アサリ', color: '#CD853F', icon: '🦪', itemCost: 8, jobCost: 12 },
+3: { name: 'ハマグリ', color: '#DAA520', icon: '🐚', itemCost: 5, jobCost: 8 },
+4: { name: 'サザエ', color: '#228B22', icon: '🐚', itemCost: 3, jobCost: 5 },
+5: { name: 'アワビ', color: '#4169E1', icon: '🦪', itemCost: 1, jobCost: 2 },
 };
 
 // 敵定義（通常＋ボス）- プレイヤーレベルに応じてスケール
 const ENEMIES = [
 // 通常敵
-{ name: ‘ウニ’, hp: 30, atk: 8, def: 3, exp: 15, drop: [1,1,1,2], color: ‘#8B008B’, icon: ‘🦔’, lv: 1, boss: false },
-{ name: ‘ヒトデ’, hp: 45, atk: 12, def: 4, exp: 25, drop: [1,2,2,2], color: ‘#FF6347’, icon: ‘⭐’, lv: 1, boss: false },
-{ name: ‘クラゲ’, hp: 40, atk: 15, def: 2, exp: 20, drop: [1,1,2,2], color: ‘#FFB6C1’, icon: ‘🪼’, lv: 2, boss: false },
-{ name: ‘タコ’, hp: 80, atk: 22, def: 8, exp: 45, drop: [2,2,3,3], color: ‘#FF4500’, icon: ‘🐙’, lv: 5, boss: false },
-{ name: ‘カニ’, hp: 100, atk: 18, def: 20, exp: 55, drop: [2,2,3,3], color: ‘#DC143C’, icon: ‘🦀’, lv: 6, boss: false },
-{ name: ‘サメ’, hp: 180, atk: 40, def: 15, exp: 120, drop: [3,3,4,4], color: ‘#4682B4’, icon: ‘🦈’, lv: 10, boss: false },
-{ name: ‘ウミガメ’, hp: 220, atk: 30, def: 35, exp: 130, drop: [3,4,4,4], color: ‘#2E8B57’, icon: ‘🐢’, lv: 12, boss: false },
-{ name: ‘シャチ’, hp: 280, atk: 55, def: 25, exp: 180, drop: [3,4,4,5], color: ‘#1C1C1C’, icon: ‘🐋’, lv: 15, boss: false },
-{ name: ‘大王イカ’, hp: 380, atk: 70, def: 30, exp: 250, drop: [4,4,5,5], color: ‘#800080’, icon: ‘🦑’, lv: 20, boss: false },
-{ name: ‘メガロドン’, hp: 550, atk: 95, def: 45, exp: 400, drop: [4,5,5,5], color: ‘#696969’, icon: ‘🦈’, lv: 28, boss: false },
-{ name: ‘海坊主’, hp: 750, atk: 110, def: 55, exp: 550, drop: [5,5,5,5], color: ‘#191970’, icon: ‘👹’, lv: 35, boss: false },
-{ name: ‘海神ワダツミ’, hp: 1200, atk: 150, def: 80, exp: 1000, drop: [5,5,5,5], color: ‘#00CED1’, icon: ‘🔱’, lv: 45, boss: false },
+{ name: 'ウニ', hp: 30, atk: 8, def: 3, exp: 15, drop: [1,1,1,2], color: '#8B008B', icon: '🦔', lv: 1, boss: false },
+{ name: 'ヒトデ', hp: 45, atk: 12, def: 4, exp: 25, drop: [1,2,2,2], color: '#FF6347', icon: '⭐', lv: 1, boss: false },
+{ name: 'クラゲ', hp: 40, atk: 15, def: 2, exp: 20, drop: [1,1,2,2], color: '#FFB6C1', icon: '🪼', lv: 2, boss: false },
+{ name: 'タコ', hp: 80, atk: 22, def: 8, exp: 45, drop: [2,2,3,3], color: '#FF4500', icon: '🐙', lv: 5, boss: false },
+{ name: 'カニ', hp: 100, atk: 18, def: 20, exp: 55, drop: [2,2,3,3], color: '#DC143C', icon: '🦀', lv: 6, boss: false },
+{ name: 'サメ', hp: 180, atk: 40, def: 15, exp: 120, drop: [3,3,4,4], color: '#4682B4', icon: '🦈', lv: 10, boss: false },
+{ name: 'ウミガメ', hp: 220, atk: 30, def: 35, exp: 130, drop: [3,4,4,4], color: '#2E8B57', icon: '🐢', lv: 12, boss: false },
+{ name: 'シャチ', hp: 280, atk: 55, def: 25, exp: 180, drop: [3,4,4,5], color: '#1C1C1C', icon: '🐋', lv: 15, boss: false },
+{ name: '大王イカ', hp: 380, atk: 70, def: 30, exp: 250, drop: [4,4,5,5], color: '#800080', icon: '🦑', lv: 20, boss: false },
+{ name: 'メガロドン', hp: 550, atk: 95, def: 45, exp: 400, drop: [4,5,5,5], color: '#696969', icon: '🦈', lv: 28, boss: false },
+{ name: '海坊主', hp: 750, atk: 110, def: 55, exp: 550, drop: [5,5,5,5], color: '#191970', icon: '👹', lv: 35, boss: false },
+{ name: '海神ワダツミ', hp: 1200, atk: 150, def: 80, exp: 1000, drop: [5,5,5,5], color: '#00CED1', icon: '🔱', lv: 45, boss: false },
 
 // ボス敵（色違い・強化版）
-{ name: ‘毒キングウニ’, hp: 80, atk: 20, def: 8, exp: 50, drop: [2,2,2,3], color: ‘#FF00FF’, icon: ‘🦔’, lv: 3, boss: true, glow: ‘#FF00FF’ },
-{ name: ‘灼熱ヒトデ’, hp: 120, atk: 30, def: 10, exp: 80, drop: [2,2,3,3], color: ‘#FF4500’, icon: ‘⭐’, lv: 5, boss: true, glow: ‘#FF4500’ },
-{ name: ‘電撃クラゲ’, hp: 100, atk: 40, def: 5, exp: 70, drop: [2,3,3,3], color: ‘#00FFFF’, icon: ‘🪼’, lv: 6, boss: true, glow: ‘#00FFFF’ },
-{ name: ‘深海大ダコ’, hp: 200, atk: 55, def: 18, exp: 150, drop: [3,3,4,4], color: ‘#8B0000’, icon: ‘🐙’, lv: 10, boss: true, glow: ‘#FF0000’ },
-{ name: ‘鋼鉄カニ’, hp: 250, atk: 45, def: 50, exp: 180, drop: [3,4,4,4], color: ‘#C0C0C0’, icon: ‘🦀’, lv: 12, boss: true, glow: ‘#FFFFFF’ },
-{ name: ‘白鯨シャーク’, hp: 400, atk: 90, def: 35, exp: 350, drop: [4,4,5,5], color: ‘#F0F8FF’, icon: ‘🦈’, lv: 18, boss: true, glow: ‘#87CEEB’ },
-{ name: ‘玄武’, hp: 500, atk: 70, def: 80, exp: 400, drop: [4,4,5,5], color: ‘#006400’, icon: ‘🐢’, lv: 22, boss: true, glow: ‘#00FF00’ },
-{ name: ‘覇王シャチ’, hp: 650, atk: 130, def: 50, exp: 550, drop: [4,5,5,5], color: ‘#4B0082’, icon: ‘🐋’, lv: 28, boss: true, glow: ‘#9400D3’ },
-{ name: ‘クラーケン’, hp: 900, atk: 160, def: 60, exp: 800, drop: [5,5,5,5], color: ‘#2F0040’, icon: ‘🦑’, lv: 35, boss: true, glow: ‘#8B008B’ },
-{ name: ‘古代メガロドン’, hp: 1300, atk: 200, def: 80, exp: 1200, drop: [5,5,5,5], color: ‘#1a1a1a’, icon: ‘🦈’, lv: 42, boss: true, glow: ‘#FFD700’ },
-{ name: ‘暴風海坊主’, hp: 1800, atk: 250, def: 100, exp: 1800, drop: [5,5,5,5], color: ‘#000033’, icon: ‘👹’, lv: 48, boss: true, glow: ‘#00BFFF’ },
-{ name: ‘龍宮の王’, hp: 3000, atk: 350, def: 150, exp: 3000, drop: [5,5,5,5], color: ‘#FFD700’, icon: ‘👑’, lv: 55, boss: true, glow: ‘#FFD700’ },
+{ name: '毒キングウニ', hp: 80, atk: 20, def: 8, exp: 50, drop: [2,2,2,3], color: '#FF00FF', icon: '🦔', lv: 3, boss: true, glow: '#FF00FF' },
+{ name: '灼熱ヒトデ', hp: 120, atk: 30, def: 10, exp: 80, drop: [2,2,3,3], color: '#FF4500', icon: '⭐', lv: 5, boss: true, glow: '#FF4500' },
+{ name: '電撃クラゲ', hp: 100, atk: 40, def: 5, exp: 70, drop: [2,3,3,3], color: '#00FFFF', icon: '🪼', lv: 6, boss: true, glow: '#00FFFF' },
+{ name: '深海大ダコ', hp: 200, atk: 55, def: 18, exp: 150, drop: [3,3,4,4], color: '#8B0000', icon: '🐙', lv: 10, boss: true, glow: '#FF0000' },
+{ name: '鋼鉄カニ', hp: 250, atk: 45, def: 50, exp: 180, drop: [3,4,4,4], color: '#C0C0C0', icon: '🦀', lv: 12, boss: true, glow: '#FFFFFF' },
+{ name: '白鯨シャーク', hp: 400, atk: 90, def: 35, exp: 350, drop: [4,4,5,5], color: '#F0F8FF', icon: '🦈', lv: 18, boss: true, glow: '#87CEEB' },
+{ name: '玄武', hp: 500, atk: 70, def: 80, exp: 400, drop: [4,4,5,5], color: '#006400', icon: '🐢', lv: 22, boss: true, glow: '#00FF00' },
+{ name: '覇王シャチ', hp: 650, atk: 130, def: 50, exp: 550, drop: [4,5,5,5], color: '#4B0082', icon: '🐋', lv: 28, boss: true, glow: '#9400D3' },
+{ name: 'クラーケン', hp: 900, atk: 160, def: 60, exp: 800, drop: [5,5,5,5], color: '#2F0040', icon: '🦑', lv: 35, boss: true, glow: '#8B008B' },
+{ name: '古代メガロドン', hp: 1300, atk: 200, def: 80, exp: 1200, drop: [5,5,5,5], color: '#1a1a1a', icon: '🦈', lv: 42, boss: true, glow: '#FFD700' },
+{ name: '暴風海坊主', hp: 1800, atk: 250, def: 100, exp: 1800, drop: [5,5,5,5], color: '#000033', icon: '👹', lv: 48, boss: true, glow: '#00BFFF' },
+{ name: '龍宮の王', hp: 3000, atk: 350, def: 150, exp: 3000, drop: [5,5,5,5], color: '#FFD700', icon: '👑', lv: 55, boss: true, glow: '#FFD700' },
 ];
 
 // 隠岐らしい装備
 const ITEMS = {
 1: [
-{ id: ‘w1a’, name: ‘漁師の銛’, type: ‘W’, rarity: ‘N’, atk: 3, def: 0, hp: 0 },
-{ id: ‘a1a’, name: ‘藁編みの胴着’, type: ‘A’, rarity: ‘N’, atk: 0, def: 3, hp: 5 },
-{ id: ‘w1b’, name: ‘貝殻の小刀’, type: ‘W’, rarity: ‘R’, atk: 5, def: 0, hp: 0 },
-{ id: ‘a1b’, name: ‘海藻の羽織’, type: ‘A’, rarity: ‘R’, atk: 0, def: 4, hp: 10 },
-{ id: ‘c1a’, name: ‘白島の護石’, type: ‘C’, rarity: ‘SR’, atk: 3, def: 3, hp: 15 },
+{ id: 'w1a', name: '漁師の銛', type: 'W', rarity: 'N', atk: 3, def: 0, hp: 0 },
+{ id: 'a1a', name: '藁編みの胴着', type: 'A', rarity: 'N', atk: 0, def: 3, hp: 5 },
+{ id: 'w1b', name: '貝殻の小刀', type: 'W', rarity: 'R', atk: 5, def: 0, hp: 0 },
+{ id: 'a1b', name: '海藻の羽織', type: 'A', rarity: 'R', atk: 0, def: 4, hp: 10 },
+{ id: 'c1a', name: '白島の護石', type: 'C', rarity: 'SR', atk: 3, def: 3, hp: 15 },
 ],
 2: [
-{ id: ‘w2a’, name: ‘隠岐杉の棍棒’, type: ‘W’, rarity: ‘N’, atk: 6, def: 0, hp: 0 },
-{ id: ‘a2a’, name: ‘牛皮の胸当て’, type: ‘A’, rarity: ‘N’, atk: 0, def: 6, hp: 10 },
-{ id: ‘w2b’, name: ‘イカ釣りの鉤槍’, type: ‘W’, rarity: ‘R’, atk: 10, def: 0, hp: 0 },
-{ id: ‘a2b’, name: ‘中ノ島の漁師合羽’, type: ‘A’, rarity: ‘R’, atk: 0, def: 8, hp: 15 },
-{ id: ‘c2a’, name: ‘西郷湾の真珠’, type: ‘C’, rarity: ‘SR’, atk: 5, def: 5, hp: 25 },
+{ id: 'w2a', name: '隠岐杉の棍棒', type: 'W', rarity: 'N', atk: 6, def: 0, hp: 0 },
+{ id: 'a2a', name: '牛皮の胸当て', type: 'A', rarity: 'N', atk: 0, def: 6, hp: 10 },
+{ id: 'w2b', name: 'イカ釣りの鉤槍', type: 'W', rarity: 'R', atk: 10, def: 0, hp: 0 },
+{ id: 'a2b', name: '中ノ島の漁師合羽', type: 'A', rarity: 'R', atk: 0, def: 8, hp: 15 },
+{ id: 'c2a', name: '西郷湾の真珠', type: 'C', rarity: 'SR', atk: 5, def: 5, hp: 25 },
 ],
 3: [
-{ id: ‘w3a’, name: ‘知夫里の鯨骨刀’, type: ‘W’, rarity: ‘R’, atk: 15, def: 0, hp: 0 },
-{ id: ‘a3a’, name: ‘サザエ殻の鎧’, type: ‘A’, rarity: ‘R’, atk: 0, def: 15, hp: 20 },
-{ id: ‘w3b’, name: ‘海士の三叉槍’, type: ‘W’, rarity: ‘SR’, atk: 20, def: 0, hp: 0 },
-{ id: ‘a3b’, name: ‘牛突きの化粧廻し’, type: ‘A’, rarity: ‘SR’, atk: 5, def: 12, hp: 30 },
-{ id: ‘c3a’, name: ‘玉若酢命の勾玉’, type: ‘C’, rarity: ‘SSR’, atk: 10, def: 10, hp: 40 },
+{ id: 'w3a', name: '知夫里の鯨骨刀', type: 'W', rarity: 'R', atk: 15, def: 0, hp: 0 },
+{ id: 'a3a', name: 'サザエ殻の鎧', type: 'A', rarity: 'R', atk: 0, def: 15, hp: 20 },
+{ id: 'w3b', name: '海士の三叉槍', type: 'W', rarity: 'SR', atk: 20, def: 0, hp: 0 },
+{ id: 'a3b', name: '牛突きの化粧廻し', type: 'A', rarity: 'SR', atk: 5, def: 12, hp: 30 },
+{ id: 'c3a', name: '玉若酢命の勾玉', type: 'C', rarity: 'SSR', atk: 10, def: 10, hp: 40 },
 ],
 4: [
-{ id: ‘w4a’, name: ‘黒曜石の太刀’, type: ‘W’, rarity: ‘SR’, atk: 30, def: 0, hp: 0 },
-{ id: ‘a4a’, name: ‘摩天崖の岩鎧’, type: ‘A’, rarity: ‘SR’, atk: 0, def: 30, hp: 35 },
-{ id: ‘w4b’, name: ‘國賀神社の神剣’, type: ‘W’, rarity: ‘SSR’, atk: 40, def: 5, hp: 0 },
-{ id: ‘a4b’, name: ‘焼火神社の神衣’, type: ‘A’, rarity: ‘SSR’, atk: 5, def: 35, hp: 50 },
-{ id: ‘c4a’, name: ‘ローソク島の聖火’, type: ‘C’, rarity: ‘UR’, atk: 20, def: 20, hp: 60 },
+{ id: 'w4a', name: '黒曜石の太刀', type: 'W', rarity: 'SR', atk: 30, def: 0, hp: 0 },
+{ id: 'a4a', name: '摩天崖の岩鎧', type: 'A', rarity: 'SR', atk: 0, def: 30, hp: 35 },
+{ id: 'w4b', name: '國賀神社の神剣', type: 'W', rarity: 'SSR', atk: 40, def: 5, hp: 0 },
+{ id: 'a4b', name: '焼火神社の神衣', type: 'A', rarity: 'SSR', atk: 5, def: 35, hp: 50 },
+{ id: 'c4a', name: 'ローソク島の聖火', type: 'C', rarity: 'UR', atk: 20, def: 20, hp: 60 },
 ],
 5: [
-{ id: ‘w5a’, name: ‘後鳥羽院の御剣’, type: ‘W’, rarity: ‘SSR’, atk: 50, def: 5, hp: 0 },
-{ id: ‘a5a’, name: ‘承久の戦装束’, type: ‘A’, rarity: ‘SSR’, atk: 5, def: 50, hp: 60 },
-{ id: ‘w5b’, name: ‘龍神の三叉戟’, type: ‘W’, rarity: ‘UR’, atk: 65, def: 10, hp: 20 },
-{ id: ‘a5b’, name: ‘隠岐国造の大鎧’, type: ‘A’, rarity: ‘UR’, atk: 10, def: 60, hp: 80 },
-{ id: ‘c5a’, name: ‘島前島後の神璽’, type: ‘C’, rarity: ‘LR’, atk: 40, def: 40, hp: 100 },
+{ id: 'w5a', name: '後鳥羽院の御剣', type: 'W', rarity: 'SSR', atk: 50, def: 5, hp: 0 },
+{ id: 'a5a', name: '承久の戦装束', type: 'A', rarity: 'SSR', atk: 5, def: 50, hp: 60 },
+{ id: 'w5b', name: '龍神の三叉戟', type: 'W', rarity: 'UR', atk: 65, def: 10, hp: 20 },
+{ id: 'a5b', name: '隠岐国造の大鎧', type: 'A', rarity: 'UR', atk: 10, def: 60, hp: 80 },
+{ id: 'c5a', name: '島前島後の神璽', type: 'C', rarity: 'LR', atk: 40, def: 40, hp: 100 },
 ],
 };
 const ALL_ITEMS = Object.values(ITEMS).flat();
 
-const RARITY_COLOR = { N: ‘#808080’, R: ‘#4169E1’, SR: ‘#9932CC’, SSR: ‘#FFD700’, UR: ‘#FF4500’, LR: ‘#00FF7F’ };
-const RARITY_LIST = [‘N’, ‘R’, ‘SR’, ‘SSR’, ‘UR’, ‘LR’];
-const TYPE_ICON = { W: ‘⚔️’, A: ‘🛡️’, C: ‘💎’ };
-const TYPE_NAME = { W: ‘武器’, A: ‘防具’, C: ‘装飾’ };
+const RARITY_COLOR = { N: '#808080', R: '#4169E1', SR: '#9932CC', SSR: '#FFD700', UR: '#FF4500', LR: '#00FF7F' };
+const RARITY_LIST = ['N', 'R', 'SR', 'SSR', 'UR', 'LR'];
+const TYPE_ICON = { W: '⚔️', A: '🛡️', C: '💎' };
+const TYPE_NAME = { W: '武器', A: '防具', C: '装飾' };
 
 const ITEM_RATES = { 1: [.4,.35,.25,0,0], 2: [.35,.35,.3,0,0], 3: [0,.35,.4,.25,0], 4: [0,0,.4,.45,.15], 5: [0,0,.3,.45,.25] };
 const JOB_RATES = { 1: {N:.8,R:.18,SR:.02}, 2: {N:.6,R:.35,SR:.05}, 3: {N:.3,R:.5,SR:.18,SSR:.02}, 4: {N:.1,R:.3,SR:.45,SSR:.14,UR:.01}, 5: {R:.1,SR:.4,SSR:.4,UR:.1} };
 
-const SPELL = ‘あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん’;
+const SPELL = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん';
 
 const encode = (p) => {
 let d = [p.level, p.exp % 47, Math.floor(p.exp / 47) % 47, JOB_IDS.indexOf(p.currentJob)];
@@ -242,30 +256,30 @@ JOB_IDS.forEach(j => d.push((p.jobLevels[j] || 1) - 1));
 d.push(p.items.length);
 p.items.forEach(it => { d.push(ALL_ITEMS.findIndex(x => x.id === it.id)); d.push((it.lv || 1) - 1); });
 d.push(d.reduce((a, b) => a + b, 0) % 47);
-return d.map(n => SPELL[n % 47]).join(’’);
+return d.map(n => SPELL[n % 47]).join('');
 };
 
 const decode = (s) => {
 try {
-const c = s.replace(/\s/g, ‘’).split(’’).map(x => SPELL.indexOf(x));
+const c = s.replace(/\s/g, '').split('').map(x => SPELL.indexOf(x));
 let i = 0;
 const level = c[i++], exp = c[i++] + c[i++] * 47, currentJob = JOB_IDS[c[i++]];
 const jf = c[i++] + c[i++] * 47;
 const unlockedJobs = JOB_IDS.filter((_, idx) => jf & (1 << idx));
-if (!unlockedJobs.includes(‘fisherman’)) unlockedJobs.push(‘fisherman’);
+if (!unlockedJobs.includes('fisherman')) unlockedJobs.push('fisherman');
 const shells = {}; for (let j = 1; j <= 5; j++) shells[j] = c[i++];
 const jobLevels = {}; JOB_IDS.forEach(j => jobLevels[j] = c[i++] + 1);
 const itemCount = c[i++], items = [];
-for (let j = 0; j < itemCount; j++) { const it = ALL_ITEMS[c[i++]]; if (it) items.push({ …it, lv: c[i++] + 1 }); else i++; }
+for (let j = 0; j < itemCount; j++) { const it = ALL_ITEMS[c[i++]]; if (it) items.push({ ...it, lv: c[i++] + 1 }); else i++; }
 return { level, exp, currentJob, unlockedJobs, shells, jobLevels, items };
 } catch { return null; }
 };
 
-export default function Game() {
-const [screen, setScreen] = useState(‘title’);
+function Game() {
+const [screen, setScreen] = useState('title');
 const [player, setPlayer] = useState({
-level: 1, exp: 0, currentJob: ‘fisherman’,
-unlockedJobs: [‘fisherman’, ‘salaryman’],
+level: 1, exp: 0, currentJob: 'fisherman',
+unlockedJobs: ['fisherman', 'salaryman'],
 shells: { 1: 5, 2: 3, 3: 1, 4: 0, 5: 0 },
 jobLevels: { fisherman: 1, salaryman: 1 },
 items: [],
@@ -274,15 +288,15 @@ const [hp, setHp] = useState(null);
 const [enemy, setEnemy] = useState(null);
 const [log, setLog] = useState([]);
 const [anim, setAnim] = useState(false);
-const [tab, setTab] = useState(‘gacha’);
+const [tab, setTab] = useState('gacha');
 const [gachaPhase, setGachaPhase] = useState(null);
 const [gachaType, setGachaType] = useState(null);
 const [gachaRank, setGachaRank] = useState(null);
 const [gachaRarity, setGachaRarity] = useState(null);
 const [result, setResult] = useState(null);
 const [showPw, setShowPw] = useState(false);
-const [pwInput, setPwInput] = useState(’’);
-const [pwError, setPwError] = useState(’’);
+const [pwInput, setPwInput] = useState('');
+const [pwError, setPwError] = useState('');
 const [showPwInput, setShowPwInput] = useState(false);
 
 const sound = useSound();
@@ -301,8 +315,8 @@ atk += Math.floor(it.atk * b);
 def += Math.floor(it.def * b);
 mhp += Math.floor(it.hp * b);
 });
-if (job.special === ‘item’ || job.special === ‘all’) { atk = Math.floor(atk * (1 + spBonus / 100)); def = Math.floor(def * (1 + spBonus / 100)); }
-if (job.special === ‘divine’ || job.special === ‘all’) { atk = Math.floor(atk * 1.1); def = Math.floor(def * 1.1); mhp = Math.floor(mhp * 1.1); }
+if (job.special === 'item' || job.special === 'all') { atk = Math.floor(atk * (1 + spBonus / 100)); def = Math.floor(def * (1 + spBonus / 100)); }
+if (job.special === 'divine' || job.special === 'all') { atk = Math.floor(atk * 1.1); def = Math.floor(def * 1.1); mhp = Math.floor(mhp * 1.1); }
 return { atk, def, mhp };
 }, [player, job, jBonus, spBonus]);
 
@@ -320,7 +334,7 @@ const lvDiff = playerLv - base.lv;
 const scale = 1 + Math.max(0, lvDiff) * 0.12; // レベル差1につき12%強化
 const bossScale = base.boss ? 1.5 : 1; // ボスは1.5倍
 return {
-…base,
+...base,
 maxHp: Math.floor(base.hp * scale * bossScale),
 hp: Math.floor(base.hp * scale * bossScale),
 atk: Math.floor(base.atk * scale * bossScale),
@@ -330,10 +344,9 @@ exp: Math.floor(base.exp * scale * (base.boss ? 2 : 1)),
 };
 
 const startBattle = () => {
-sound(‘button’);
+sound('button');
 if (curHp <= 0) setHp(maxHp);
 
-```
 // レベルに応じた敵を選択（ボス20%出現）
 const isBoss = Math.random() < 0.2;
 const availEnemies = ENEMIES.filter(e => e.boss === isBoss && e.lv <= player.level + 8 && e.lv >= player.level - 10);
@@ -346,16 +359,14 @@ if (scaled.boss) sound('boss');
 setEnemy(scaled);
 setLog([`${scaled.boss ? '⚠️ BOSS! ' : ''}${scaled.name}が現れた！`]);
 setScreen('battle');
-```
 
 };
 
 const doAttack = () => {
 if (!enemy || anim) return;
 setAnim(true);
-sound(‘attack’);
+sound('attack');
 
-```
 const sp = job.special;
 let dmg = Math.max(1, stats.atk - Math.floor(enemy.def / ((sp === 'pierce' || sp === 'all') ? 3 : 2)));
 const isCrit = Math.random() < ((sp === 'crit' || sp === 'all') ? spBonus / 100 : 0.05);
@@ -392,7 +403,6 @@ if (newEHp <= 0) {
 }
 setLog(newLog.slice(-5));
 setTimeout(() => setAnim(false), 200);
-```
 
 };
 
@@ -403,93 +413,92 @@ return { spin: 1000 + i * 200, build: i >= 2 ? 1000 + i * 500 : 0 };
 
 const pullItem = (rank) => {
 if (player.shells[rank] < SHELLS[rank].itemCost) return;
-sound(‘gacha’);
-setPlayer(p => ({ …p, shells: { …p.shells, [rank]: p.shells[rank] - SHELLS[rank].itemCost } }));
-setGachaRank(rank); setGachaType(‘item’); setGachaPhase(‘spin’);
+sound('gacha');
+setPlayer(p => ({ ...p, shells: { ...p.shells, [rank]: p.shells[rank] - SHELLS[rank].itemCost } }));
+setGachaRank(rank); setGachaType('item'); setGachaPhase('spin');
 let r = Math.random(), idx = 0;
 ITEM_RATES[rank].forEach((rate, i) => { if (r > 0) { r -= rate; if (r <= 0) idx = i; } });
 const item = ITEMS[rank][idx];
 setGachaRarity(item.rarity);
 const t = getTiming(item.rarity);
 setTimeout(() => {
-if (t.build > 0) { setGachaPhase(‘build’); sound(‘gachaRare’); setTimeout(() => finishItem(item), t.build); }
+if (t.build > 0) { setGachaPhase('build'); sound('gachaRare'); setTimeout(() => finishItem(item), t.build); }
 else finishItem(item);
 }, t.spin);
 };
 
 const finishItem = (item) => {
-setGachaPhase(‘result’);
-sound(‘gachaHit’);
+setGachaPhase('result');
+sound('gachaHit');
 const idx = player.items.findIndex(x => x.id === item.id);
 if (idx >= 0) {
 const newLv = Math.min(10, (player.items[idx].lv || 1) + 1);
-const newItems = […player.items]; newItems[idx] = { …newItems[idx], lv: newLv };
-setPlayer(p => ({ …p, items: newItems }));
-setResult({ …item, lv: newLv, isUp: true });
+const newItems = [...player.items]; newItems[idx] = { ...newItems[idx], lv: newLv };
+setPlayer(p => ({ ...p, items: newItems }));
+setResult({ ...item, lv: newLv, isUp: true });
 } else {
-setPlayer(p => ({ …p, items: […p.items, { …item, lv: 1 }] }));
-setResult({ …item, lv: 1, isUp: false });
+setPlayer(p => ({ ...p, items: [...p.items, { ...item, lv: 1 }] }));
+setResult({ ...item, lv: 1, isUp: false });
 }
 };
 
 const pullJob = (rank) => {
 if (player.shells[rank] < SHELLS[rank].jobCost) return;
-sound(‘gacha’);
-setPlayer(p => ({ …p, shells: { …p.shells, [rank]: p.shells[rank] - SHELLS[rank].jobCost } }));
-setGachaRank(rank); setGachaType(‘job’); setGachaPhase(‘spin’);
+sound('gacha');
+setPlayer(p => ({ ...p, shells: { ...p.shells, [rank]: p.shells[rank] - SHELLS[rank].jobCost } }));
+setGachaRank(rank); setGachaType('job'); setGachaPhase('spin');
 const byR = {}; Object.entries(JOBS).forEach(([id, j]) => { byR[j.rarity] = byR[j.rarity] || []; byR[j.rarity].push(id); });
-let r = Math.random(), rarity = ‘N’;
+let r = Math.random(), rarity = 'N';
 Object.entries(JOB_RATES[rank] || {}).forEach(([ra, rate]) => { if (r > 0) { r -= rate; if (r <= 0) rarity = ra; } });
-const jobId = byR[rarity]?.[Math.floor(Math.random() * (byR[rarity]?.length || 1))] || ‘fisherman’;
+const jobId = byR[rarity]?.[Math.floor(Math.random() * (byR[rarity]?.length || 1))] || 'fisherman';
 setGachaRarity(JOBS[jobId].rarity);
 const t = getTiming(JOBS[jobId].rarity);
 setTimeout(() => {
-if (t.build > 0) { setGachaPhase(‘build’); sound(‘gachaRare’); setTimeout(() => finishJob(jobId), t.build); }
+if (t.build > 0) { setGachaPhase('build'); sound('gachaRare'); setTimeout(() => finishJob(jobId), t.build); }
 else finishJob(jobId);
 }, t.spin);
 };
 
 const finishJob = (jobId) => {
-setGachaPhase(‘result’);
-sound(‘gachaHit’);
+setGachaPhase('result');
+sound('gachaHit');
 const isNew = !player.unlockedJobs.includes(jobId);
 const newLv = Math.min(10, (player.jobLevels[jobId] || 0) + 1);
 setPlayer(p => ({
-…p,
-unlockedJobs: isNew ? […p.unlockedJobs, jobId] : p.unlockedJobs,
-jobLevels: { …p.jobLevels, [jobId]: newLv },
+...p,
+unlockedJobs: isNew ? [...p.unlockedJobs, jobId] : p.unlockedJobs,
+jobLevels: { ...p.jobLevels, [jobId]: newLv },
 }));
-setResult({ type: ‘job’, jobId, job: JOBS[jobId], lv: newLv, isNew });
+setResult({ type: 'job', jobId, job: JOBS[jobId], lv: newLv, isNew });
 };
 
 const closeResult = () => { setResult(null); setGachaPhase(null); setGachaRarity(null); };
 
 const handlePw = () => {
 const d = decode(pwInput);
-if (d) { setPlayer(d); setHp(null); setPwError(’’); setShowPwInput(false); setPwInput(’’); setScreen(‘home’); sound(‘levelup’); }
-else setPwError(‘じゅもんが ちがいます’);
+if (d) { setPlayer(d); setHp(null); setPwError(''); setShowPwInput(false); setPwInput(''); setScreen('home'); sound('levelup'); }
+else setPwError('じゅもんが ちがいます');
 };
 
-const ri = RARITY_LIST.indexOf(gachaRarity || ‘N’);
+const ri = RARITY_LIST.indexOf(gachaRarity || 'N');
 
 // タイトル
-if (screen === ‘title’) return (
+if (screen === 'title') return (
 <div style={{
-minHeight: ‘100vh’,
-background: ‘linear-gradient(180deg, #000510 0%, #001030 30%, #002855 60%, #004080 100%)’,
-fontFamily: ‘“Hiragino Kaku Gothic Pro”, “Yu Gothic”, sans-serif’,
-display: ‘flex’,
-flexDirection: ‘column’,
-alignItems: ‘center’,
-justifyContent: ‘center’,
-position: ‘relative’,
-overflow: ‘hidden’,
+minHeight: '100vh',
+background: 'linear-gradient(180deg, #000510 0%, #001030 30%, #002855 60%, #004080 100%)',
+fontFamily: '"Hiragino Kaku Gothic Pro", "Yu Gothic", sans-serif',
+display: 'flex',
+flexDirection: 'column',
+alignItems: 'center',
+justifyContent: 'center',
+position: 'relative',
+overflow: 'hidden',
 }}>
 {/* 海の波アニメーション */}
-<div style={{ position: ‘absolute’, bottom: 0, left: 0, right: 0, height: ‘30%’, background: ‘linear-gradient(180deg, transparent 0%, rgba(0,100,180,0.3) 50%, rgba(0,150,220,0.4) 100%)’, animation: ‘wave 4s ease-in-out infinite’ }} />
-<div style={{ position: ‘absolute’, bottom: 0, left: 0, right: 0, height: ‘25%’, background: ‘linear-gradient(180deg, transparent 0%, rgba(0,80,150,0.2) 50%, rgba(0,120,200,0.3) 100%)’, animation: ‘wave 3s ease-in-out infinite reverse’ }} />
+<div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '30%', background: 'linear-gradient(180deg, transparent 0%, rgba(0,100,180,0.3) 50%, rgba(0,150,220,0.4) 100%)', animation: 'wave 4s ease-in-out infinite' }} />
+<div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '25%', background: 'linear-gradient(180deg, transparent 0%, rgba(0,80,150,0.2) 50%, rgba(0,120,200,0.3) 100%)', animation: 'wave 3s ease-in-out infinite reverse' }} />
 
-```
   {/* 浮遊する泡 */}
   {[...Array(15)].map((_, i) => (
     <div key={i} style={{
@@ -654,25 +663,23 @@ overflow: ‘hidden’,
     }
   `}</style>
 </div>
-```
 
 );
 
 // バトル
-if (screen === ‘battle’) return (
-<div style={{ minHeight: ‘100vh’, background: ‘linear-gradient(180deg,#0a1628,#1a3a5c)’, fontFamily: ‘sans-serif’, padding: 15 }}>
-<div style={{ display: ‘flex’, justifyContent: ‘space-between’, alignItems: ‘center’, marginBottom: 15 }}>
-<div style={{ background: ‘rgba(0,0,0,0.5)’, padding: 10, borderRadius: 10, border: `2px solid ${job.color}` }}>
+if (screen === 'battle') return (
+<div style={{ minHeight: '100vh', background: 'linear-gradient(180deg,#0a1628,#1a3a5c)', fontFamily: 'sans-serif', padding: 15 }}>
+<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 15 }}>
+<div style={{ background: 'rgba(0,0,0,0.5)', padding: 10, borderRadius: 10, border: `2px solid ${job.color}` }}>
 <div style={{ color: job.color, fontSize: 12 }}>{job.icon} {job.name} JLv{jLv} / PLv{player.level}</div>
-<div style={{ width: 120, height: 12, background: ‘#222’, borderRadius: 6, overflow: ‘hidden’, marginTop: 5 }}>
-<div style={{ width: `${curHp / maxHp * 100}%`, height: ‘100%’, background: ‘#f44’ }} />
+<div style={{ width: 120, height: 12, background: '#222', borderRadius: 6, overflow: 'hidden', marginTop: 5 }}>
+<div style={{ width: `${curHp / maxHp * 100}%`, height: '100%', background: '#f44' }} />
 </div>
-<div style={{ color: ‘#fff’, fontSize: 10 }}>HP:{curHp}/{maxHp} 攻:{stats.atk} 防:{stats.def}</div>
+<div style={{ color: '#fff', fontSize: 10 }}>HP:{curHp}/{maxHp} 攻:{stats.atk} 防:{stats.def}</div>
 </div>
-<button onClick={() => { sound(‘button’); setEnemy(null); setLog([]); setScreen(‘home’); }} style={{ padding: ‘8px 15px’, background: ‘#555’, border: ‘none’, borderRadius: 15, color: ‘#fff’, cursor: ‘pointer’, fontSize: 12 }}>逃げる</button>
+<button onClick={() => { sound('button'); setEnemy(null); setLog([]); setScreen('home'); }} style={{ padding: '8px 15px', background: '#555', border: 'none', borderRadius: 15, color: '#fff', cursor: 'pointer', fontSize: 12 }}>逃げる</button>
 </div>
 
-```
   {enemy && (
     <div style={{ textAlign: 'center', marginBottom: 20 }}>
       {enemy.boss && (
@@ -720,31 +727,29 @@ if (screen === ‘battle’) return (
     }
   `}</style>
 </div>
-```
 
 );
 
 // ホーム
 return (
-<div style={{ minHeight: ‘100vh’, background: ‘linear-gradient(180deg,#1a1a2e,#16213e)’, fontFamily: ‘sans-serif’, padding: 12 }}>
+<div style={{ minHeight: '100vh', background: 'linear-gradient(180deg,#1a1a2e,#16213e)', fontFamily: 'sans-serif', padding: 12 }}>
 {/* ガチャ演出 */}
-{(gachaPhase === ‘spin’ || gachaPhase === ‘build’) && (
-<div style={{ position: ‘fixed’, inset: 0, background: gachaPhase === ‘build’ ? `radial-gradient(circle,${RARITY_COLOR[gachaRarity]}44,#000)` : ‘#000’, display: ‘flex’, alignItems: ‘center’, justifyContent: ‘center’, zIndex: 100 }}>
-{gachaPhase === ‘spin’ && <div style={{ fontSize: 100, animation: ‘spin 1s linear infinite’ }}>{gachaType === ‘job’ ? ‘👤’ : SHELLS[gachaRank]?.icon}</div>}
-{gachaPhase === ‘build’ && (
-<div style={{ textAlign: ‘center’, position: ‘relative’ }}>
-{ri >= 2 && <div style={{ position: ‘absolute’, top: ‘50%’, left: ‘50%’, transform: ‘translate(-50%,-50%)’, width: 200, height: 200, border: `3px solid ${RARITY_COLOR[gachaRarity]}`, borderRadius: ‘50%’, borderTopColor: ‘transparent’, animation: ‘spin 1s linear infinite’ }} />}
-{ri >= 4 && <div style={{ position: ‘absolute’, top: ‘50%’, left: ‘50%’, transform: ‘translate(-50%,-50%)’, width: 250, height: 250, background: ‘conic-gradient(red,yellow,lime,aqua,blue,magenta,red)’, borderRadius: ‘50%’, animation: ‘spin 2s linear infinite’, opacity: 0.3, filter: ‘blur(10px)’ }} />}
-<div style={{ fontSize: 80, position: ‘relative’, animation: ri >= 3 ? ‘shake 0.1s infinite’ : ‘pulse 0.5s infinite’, filter: `drop-shadow(0 0 30px ${RARITY_COLOR[gachaRarity]})` }}>❓</div>
-<div style={{ color: RARITY_COLOR[gachaRarity], fontSize: 20, marginTop: 20, fontWeight: ‘bold’ }}>
-{ri >= 5 ? ‘！！伝説の輝き！！’ : ri >= 4 ? ‘！神々しい光！’ : ri >= 3 ? ‘金色の光が！’ : ‘紫の光…’}
+{(gachaPhase === 'spin' || gachaPhase === 'build') && (
+<div style={{ position: 'fixed', inset: 0, background: gachaPhase === 'build' ? `radial-gradient(circle,${RARITY_COLOR[gachaRarity]}44,#000)` : '#000', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100 }}>
+{gachaPhase === 'spin' && <div style={{ fontSize: 100, animation: 'spin 1s linear infinite' }}>{gachaType === 'job' ? '👤' : SHELLS[gachaRank]?.icon}</div>}
+{gachaPhase === 'build' && (
+<div style={{ textAlign: 'center', position: 'relative' }}>
+{ri >= 2 && <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', width: 200, height: 200, border: `3px solid ${RARITY_COLOR[gachaRarity]}`, borderRadius: '50%', borderTopColor: 'transparent', animation: 'spin 1s linear infinite' }} />}
+{ri >= 4 && <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', width: 250, height: 250, background: 'conic-gradient(red,yellow,lime,aqua,blue,magenta,red)', borderRadius: '50%', animation: 'spin 2s linear infinite', opacity: 0.3, filter: 'blur(10px)' }} />}
+<div style={{ fontSize: 80, position: 'relative', animation: ri >= 3 ? 'shake 0.1s infinite' : 'pulse 0.5s infinite', filter: `drop-shadow(0 0 30px ${RARITY_COLOR[gachaRarity]})` }}>❓</div>
+<div style={{ color: RARITY_COLOR[gachaRarity], fontSize: 20, marginTop: 20, fontWeight: 'bold' }}>
+{ri >= 5 ? '！！伝説の輝き！！' : ri >= 4 ? '！神々しい光！' : ri >= 3 ? '金色の光が！' : '紫の光...'}
 </div>
 </div>
 )}
 </div>
 )}
 
-```
   {/* 結果表示 */}
   {result && gachaPhase === 'result' && (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.95)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100 }}>
@@ -919,7 +924,12 @@ return (
     @keyframes shake { 0%,100% { transform: translateX(0); } 25% { transform: translateX(-5px); } 75% { transform: translateX(5px); } }
   `}</style>
 </div>
-```
 
 );
 }
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<Game />);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- The file previously contained module-only/JSX source (ESM `import`/`export` and smart quotes/fenced snippets) that prevented opening it directly in a browser. 
- The goal was to produce a self-contained HTML that can be opened in a browser without a build step so the game can run as-is.

### Description
- Wrap the existing JSX module in a full HTML template that includes UMD React/ReactDOM and Babel from CDNs and a `#root` container so the app can be mounted in-browser. 
- Convert module syntax to globals by replacing `import`/`export default` with `const { ... } = React;` and `function Game(){...}` and append `ReactDOM.createRoot(...).render(<Game />);` at the end. 
- Normalize smart quotes, remove leftover Markdown code fences and stray Unicode ellipses, and fix string/JS syntax so the script can run under `type=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809c9a47b0832fbdfc794f38a9823f)